### PR TITLE
Refactor/configure ways

### DIFF
--- a/frontend/classes.php
+++ b/frontend/classes.php
@@ -23,7 +23,7 @@ class Demo
                      'REDISSERVER', 'REDISPORT', 'MEMCACHEDSERVER', 'MEMCACHEDPORT'];
         foreach ($varnames as $var) {
             if (getenv($var) === false) {
-                throw new Exception("Missing environment variable '$var'");
+                throw new \Exception("Missing environment variable '$var'");
             }
             $this->environment[$var] = getenv($var);
         }

--- a/frontend/functions.php
+++ b/frontend/functions.php
@@ -11,10 +11,9 @@ function loopMeParameterised($count)
     return $n;
 }
 
-function showResultRow($technique, $time)
+function showResultRow($technique, $time, $base)
 {
-    global $totalLoop;
     echo "<tr><td>$technique</td>";
-    echo '<td>', round($time, PRECISION), ' s</td><td>', round($time / $totalLoop, PRECISION), "</td></tr>\n";
+    echo '<td>', round($time, PRECISION), ' s</td><td>', round($time / $base, PRECISION), "</td></tr>\n";
     flush();
 }

--- a/frontend/functions.php
+++ b/frontend/functions.php
@@ -1,28 +1,14 @@
 <?php
 
-function loopMeUnparameterised()
-{
-    $Iterations = (empty($_REQUEST['I']) || !is_numeric($_REQUEST['I'])) ? ITERATIONS : (int)$_REQUEST['I'];
-    $starttime = microtime(true);
-    $n = 0;
-    $i = 0;
-    while ($i < $Iterations) {
-        $n = $n + rand();
-        $i++;
-    }
-    return microtime(true) - $starttime;
-}
-
 function loopMeParameterised($count)
 {
-    $starttime = microtime(true);
     $n = 0;
     $i = 0;
     while ($i < $count) {
         $n = $n + rand();
         $i++;
     }
-    return microtime(true) - $starttime;
+    return $n;
 }
 
 function showResultRow($technique, $time)

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -2,6 +2,7 @@
 
 const ITERATIONS = 10;
 const PRECISION = 5;
+const SERIES_NAMES = ['On-page looping', 'Class-based looping', 'External data source'];
 
 require_once '/var/www/vendor/autoload.php';
 
@@ -55,7 +56,7 @@ echo '<table class="table table-striped" id="resultsTable">
     <tbody>';
 
 $times = [];
-$series = array_fill(0, 3, array_fill(0, count(Ways(null, 'Index')), 0));
+$series = array_fill(0, count(SERIES_NAMES), array_fill(0, count(Ways(null, 'Index')), 0));
 // Loop over our configured ways. There's a bit of code duplication here, to
 // try and ensure that only what we're measuring is inside the timing loop,
 // not additional structural conditionals.
@@ -154,7 +155,7 @@ foreach (Ways(null, 'Graph') as $caption) {
 echo "            ]\n        },\n";
 
 $json = [];
-foreach (['On-page looping', 'Class-based looping', 'External data source'] as $i => $name) {
+foreach (SERIES_NAMES as $i => $name) {
     $json[] = ['name' => $name, 'data' => $series[$i]];
 }
 echo '        series: ', json_encode($json, JSON_PRETTY_PRINT), ",\n";

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -2,12 +2,12 @@
 
 const ITERATIONS = 10;
 const PRECISION = 5;
-const NUMBERFORMAT = 8;
 
 require_once '/var/www/vendor/autoload.php';
 
-include 'classes.php';
-include 'functions.php';
+include_once 'classes.php';
+include_once 'functions.php';
+include_once 'ways.php';
 
 // We do NOT use a Template builder
 // This is because we want to keep flushing the output after each test type
@@ -45,23 +45,8 @@ $Iterations = (empty($_REQUEST['I']) || !is_numeric($_REQUEST['I'])) ? ITERATION
 $displayIterations = number_format($Iterations);
 $myclass = new MHL\Demo($Iterations);
 
-// $_SERVER['SCRIPT_URI'] is set by mod_rewrite, but not otherwise.
-if (empty($_SERVER['SCRIPT_URI'])) {
-    $_SERVER['SCRIPT_URI'] = (!empty($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] != 'off')) ? 'https' : 'http';
-    $_SERVER['SCRIPT_URI'] .= "://$_SERVER[SERVER_NAME]$_SERVER[SCRIPT_NAME]";
-}
-
 echo "<div class='alert alert-success'>Running $displayIterations iterations of each loop.</div>";
 flush();
-
-$starttime = microtime(true);
-$i = 0;
-$n = 0;
-while ($i < $Iterations) {
-    $n = $n + rand();
-    $i++;
-}
-$totalLoop = microtime(true) - $starttime;
 
 echo '<h2>Results</h2>';
 
@@ -69,90 +54,46 @@ echo '<table class="table table-striped" id="resultsTable">
     <thead><th>Method</th><th>Time</th><th>Factor</th></thead>
     <tbody>';
 
-showResultRow('Page: Simple loop', $totalLoop);
-
-$starttime = microtime(true);
-loopMeParameterised($Iterations);
-$paramtime = microtime(true) - $starttime;
-showResultRow('Page: Local function doing the iteration internally', $paramtime);
-
-$starttime = microtime(true);
-$i = $n = 0;
-while ($i < $Iterations) {
-    $n = $n + loopMeParameterised(1);
-    $i++;
-}
-$unparamtime = microtime(true) - $starttime;
-showResultRow('Page: Local function called multiple times', $unparamtime);
-
-$starttime = microtime(true);
-$n = $myclass->getN($Iterations);
-$classGetN = microtime(true) - $starttime;
-showResultRow('Class: Single method call that did the iteration in the method', $classGetN);
-
-$starttime = microtime(true);
-$i = 0;
-while ($i < $Iterations) {
-    $myclass->getN(1);
-    $i++;
-}
-$classGet1 = microtime(true) - $starttime;
-showResultRow('Class: Call the method multiple times from a loop in the calling page', $classGet1);
-
-$starttime = microtime(true);
-$n = $myclass->getNFromMemcached($Iterations);
-$classGetNFromMemcached = microtime(true) - $starttime;
-showResultRow(
-    'External: Single method call, that ran a loop calling class shared memcached each time',
-    $classGetNFromMemcached
-);
-
-$starttime = microtime(true);
-$n = $myclass->getNFromRedis($Iterations);
-$classGetNFromRedis = round(microtime(true) - $starttime, PRECISION);
-showResultRow(
-    'External: Single method call, that ran a loop calling class shared Redis each time',
-    $classGetNFromRedis
-);
-
-$starttime = microtime(true);
-$n = $myclass->getNFromDBQuery($Iterations);
-$classgetNFromDBQuery = round(microtime(true) - $starttime, PRECISION);
-showResultRow(
-    'External: Single method call, that ran a loop calling a new MySQL query each time',
-    $classgetNFromDBQuery
-);
-
-$starttime = microtime(true);
-$n = $myclass->getNFromDBQueryInOneGo($Iterations);
-$classgetNFromDBQueryInOneGo = round(microtime(true) - $starttime, PRECISION);
-showResultRow(
-    'External: Single method call, that ran one MySQL query then looped over the returned data',
-    $classgetNFromDBQueryInOneGo
-);
-
-$starttime = microtime(true);
-$n = $myclass->getNFromSQLite($Iterations);
-$classgetNFromSQLite = round(microtime(true) - $starttime, PRECISION);
-showResultRow(
-    'External: Single method call, that ran a loop calling a new SQLite query each time',
-    $classgetNFromSQLite
-);
-
-$starttime = microtime(true);
-$n = $myclass->getNFromAPI($Iterations);
-$classGetNFromAPI = round(microtime(true) - $starttime, PRECISION);
-showResultRow(
-    'External: Single method call, that ran a loop calling class shared API each time',
-    $classGetNFromAPI
-);
-
-$times = ['totalLoop', 'unparamtime', 'paramtime', 'classGetN', 'classGet1',
-          'classGetNFromMemcached', 'classGetNFromRedis',
-          'classgetNFromDBQuery', 'classgetNFromDBQueryInOneGo', 'classgetNFromSQLite',
-          'classGetNFromAPI'];
-foreach ($times as $var) {
-    $$var = number_format($$var, NUMBERFORMAT);
+$times = [];
+$series = array_fill(0, 3, array_fill(0, count(Ways(null, 'Index')), 0));
+// Loop over our configured ways. There's a bit of code duplication here, to
+// try and ensure that only what we're measuring is inside the timing loop,
+// not additional structural conditionals.
+foreach (Ways() as $index => $way) {
+    if ($index == 0) {
+        // handle the basic in-page loop separately
+        $starttime = microtime(true);
+        for ($i = $n = 0; $i < $Iterations; ++$i) {
+            $n += rand();
+        }
+        $times[$index] = microtime(true) - $starttime;
+    } elseif ($way['Loop']) {
+        if ($way['Class']) {
+            $starttime = microtime(true);
+            for ($i = $n = 0; $i < $Iterations; ++$i) {
+                $n += call_user_func([$myclass, $way['Function']], 1);
+            }
+            $times[$index] = microtime(true) - $starttime;
+        } else {
+            $starttime = microtime(true);
+            for ($i = $n = 0; $i < $Iterations; ++$i) {
+                $n += call_user_func($way['Function'], 1);
+            }
+            $times[$index] = microtime(true) - $starttime;
+        }
+    } else {
+        if ($way['Class']) {
+            $starttime = microtime(true);
+            $n += call_user_func([$myclass, $way['Function']], $Iterations);
+            $times[$index] = microtime(true) - $starttime;
+        } else {
+            $starttime = microtime(true);
+            $n += call_user_func($way['Function'], $Iterations);
+            $times[$index] = microtime(true) - $starttime;
+        }
+    }
+    showResultRow($way['Table'], $times[$index], $times[0]);
+    $series[$way['Series']][$index] = $times[$index];
 }
 
 echo <<< FORM_TOP
@@ -173,15 +114,19 @@ FORM_TOP;
 
 if (empty($_REQUEST['axis']) || ($_REQUEST['axis'] != 'lin')) { // log axis, default
     echo "    <input type='hidden' id='axis' name='axis' value='log'>\n";
-    echo "    <button type='button' class='btn btn-primary active' id='logaxis' data-axis='log'> Logarithmic</button>";
-    echo "    <button type='button' class='btn btn-primary' id='linaxis' data-axis='lin'> Linear</button>";
+    echo "    <button type='button' class='btn btn-primary active' id='logaxis' data-axis='log'> ";
+    echo "Logarithmic</button>\n";
+    echo "    <button type='button' class='btn btn-primary' id='linaxis' data-axis='lin'> ";
+    echo "Linear</button>\n";
 } else {
     echo "    <input type='hidden' id='axis' name='axis' value='lin'>\n";
-    echo "    <button type='button' class='btn btn-primary' id='logaxis' data-axis='log'> Logarithmic</button>";
-    echo "    <button type='button' class='btn btn-primary active' id='linaxis' data-axis='lin'> Linear</button>";
+    echo "    <button type='button' class='btn btn-primary' id='logaxis' data-axis='log'> ";
+    echo "Logarithmic</button>\n";
+    echo "    <button type='button' class='btn btn-primary active' id='linaxis' data-axis='lin'>";
+    echo " Linear</button>\n";
 }
 
-echo <<< PAGE_END
+echo <<< SCRIPT_TOP
   </p>
 </form>
 
@@ -201,19 +146,20 @@ $(function() {
         },
         xAxis: {
             categories: [
-                'Simple loop',
-                'Local function called once',
-                'Local function called per iteration',
-                'Loop inside a single method call',
-                'Method called once per iteration',
-                'Memcached',
-                'Redis',
-                'MySQL (n queries)',
-                'MySQL (one query)',
-                'SQLite',
-                'API',
-            ]
-        },
+
+SCRIPT_TOP;
+foreach (Ways(null, 'Graph') as $caption) {
+    echo "                '$caption',\n";
+}
+echo "            ]\n        },\n";
+
+$json = [];
+foreach (['On-page looping', 'Class-based looping', 'External data source'] as $i => $name) {
+    $json[] = ['name' => $name, 'data' => $series[$i]];
+}
+echo '        series: ', json_encode($json, JSON_PRETTY_PRINT), ",\n";
+
+echo <<< PAGE_END
         yAxis: {
             type: ($('#axis').val() == 'log') ? 'logarithmic' : 'linear',
             minorTickInterval: 'auto',
@@ -241,56 +187,7 @@ $(function() {
                 }
                 return txt;
             }
-        },
-        series: [{
-            name: 'On-page looping',
-            data: [
-                $totalLoop,
-                $paramtime,
-                $unparamtime,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0
-            ]
-        },
-        {
-            name: 'Class-based looping',
-            data: [
-                0,
-                0,
-                0,
-                $classGetN,
-                $classGet1,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0
-            ]
-        },
-        {
-            name: 'External data source',
-            data: [
-                0,
-                0,
-                0,
-                0,
-                0,
-                $classGetNFromMemcached,
-                $classGetNFromRedis,
-                $classgetNFromDBQuery,
-                $classgetNFromDBQueryInOneGo,
-                $classgetNFromSQLite,
-                $classGetNFromAPI
-            ]
         }
-    ]
     });
 
     $('#logaxis, #linaxis').click(function() {

--- a/frontend/index.php
+++ b/frontend/index.php
@@ -71,11 +71,19 @@ echo '<table class="table table-striped" id="resultsTable">
 
 showResultRow('Page: Simple loop', $totalLoop);
 
-$unparamtime = loopMeUnparameterised();
-showResultRow('Page: Unparameterised local function', $unparamtime);
+$starttime = microtime(true);
+loopMeParameterised($Iterations);
+$paramtime = microtime(true) - $starttime;
+showResultRow('Page: Local function doing the iteration internally', $paramtime);
 
-$paramtime = loopMeParameterised($Iterations);
-showResultRow('Page: Parameterised local function', $paramtime);
+$starttime = microtime(true);
+$i = $n = 0;
+while ($i < $Iterations) {
+    $n = $n + loopMeParameterised(1);
+    $i++;
+}
+$unparamtime = microtime(true) - $starttime;
+showResultRow('Page: Local function called multiple times', $unparamtime);
 
 $starttime = microtime(true);
 $n = $myclass->getN($Iterations);
@@ -194,8 +202,8 @@ $(function() {
         xAxis: {
             categories: [
                 'Simple loop',
-                'Local unparameterised function',
-                'Local parameterised function',
+                'Local function called once',
+                'Local function called per iteration',
                 'Loop inside a single method call',
                 'Method called once per iteration',
                 'Memcached',
@@ -238,8 +246,8 @@ $(function() {
             name: 'On-page looping',
             data: [
                 $totalLoop,
-                $unparamtime,
                 $paramtime,
+                $unparamtime,
                 0,
                 0,
                 0,
@@ -286,7 +294,6 @@ $(function() {
     });
 
     $('#logaxis, #linaxis').click(function() {
-        console.log('Click: ' + this.id);
         $('#axis').val($(this).data('axis'));
         $('#axisChoice button').removeClass('active');
         $(this).addClass('active');

--- a/frontend/ways.php
+++ b/frontend/ways.php
@@ -1,0 +1,136 @@
+<?php
+
+function Ways($index = null, $element = null)
+{
+    // Our configuration. For each "way", we have:
+    //  Table : the "long" caption for the results table
+    //  Graph : the "short" caption, for the graph
+    //  Class : a boolean (for now, anyway), true if this is a class method
+    //  Function : the function/method to be invoked
+    //  Loop : boolean true if the caller needs to do the looping
+    //  Series : the number of the series (0..2) this way appears in the
+    //      charts under
+    $Ways = [ [ 'Table' => 'Page: Simple loop',
+                'Graph' => 'Simple loop',
+                'Class' => false,
+                'Function' => null,
+                'Loop' => true,
+                'Series' => 0,
+              ],
+              [ 'Table' => 'Page: Local function doing the iteration internally',
+                'Graph' => 'Local function called once',
+                'Class' => false,
+                'Function' => 'loopMeParameterised',
+                'Loop' => false,
+                'Series' => 0,
+              ],
+              [ 'Table' => 'Page: Local function called multiple times',
+                'Graph' => 'Local function called per iteration',
+                'Class' => false,
+                'Function' => 'loopMeParameterised',
+                'Loop' => true,
+                'Series' => 0,
+              ],
+              [ 'Table' => 'Class: Single method call that did the iteration in the method',
+                'Graph' => 'Loop inside a single method call',
+                'Class' => true,
+                'Function' => 'getN',
+                'Loop' => false,
+                'Series' => 1,
+              ],
+              [ 'Table' => 'Class: Call the method multiple times from a loop in the calling page',
+                'Graph' => 'Method called once per iteration',
+                'Class' => true,
+                'Function' => 'getN',
+                'Loop' => true,
+                'Series' => 1,
+              ],
+              [ 'Table' => 'External: Single method call, that ran a loop calling class shared memcached each time',
+                'Graph' => 'Memcached',
+                'Class' => true,
+                'Function' => 'getNFromMemcached',
+                'Loop' => false,
+                'Series' => 2,
+              ],
+              [ 'Table' => 'External: Single method call, that ran a loop calling class shared Redis each time',
+                'Graph' => 'Redis',
+                'Class' => true,
+                'Function' => 'getNFromRedis',
+                'Loop' => false,
+                'Series' => 2,
+              ],
+              [ 'Table' => 'External: Single method call, that ran a loop calling a new MySQL query each time',
+                'Graph' => 'MySQL (n queries)',
+                'Class' => true,
+                'Function' => 'getNFromDBQuery',
+                'Loop' => false,
+                'Series' => 2,
+              ],
+              [ 'Table' => 'External: Single method call, that ran one MySQL query then looped over the returned data',
+                'Graph' => 'MySQL (one query)',
+                'Class' => true,
+                'Function' => 'getNFromDBQueryInOneGo',
+                'Loop' => false,
+                'Series' => 2,
+              ],
+              [ 'Table' => 'External: Single method call, that ran a loop calling a new SQLite query each time',
+                'Graph' => 'SQLite',
+                'Class' => true,
+                'Function' => 'getNFromSQLite',
+                'Loop' => false,
+                'Series' => 2,
+              ],
+              [ 'Table' => 'External: Single method call, that ran a loop calling class shared API each time',
+                'Graph' => 'API',
+                'Class' => true,
+                'Function' => 'getNFromAPI',
+                'Loop' => false,
+                'Series' => 2,
+              ],
+            ];
+
+    if (is_null($index)) {
+        // If we're not given an index, we return an array
+        if (is_null($element)) {
+            // Not given an element either, just return everything!
+            return $Ways;
+        }
+
+        if ($element == 'Index') {
+            // an element of Index is a fake
+            return array_keys($Ways);
+        }
+        return array_map(function ($x) use ($element) {
+            return $x[$element] ?? null;
+        }, $Ways);
+    }
+
+    // We've got an index. If it's numeric, we want that one; if it's a
+    // string, it should match one of the captions
+    if (!is_numeric($index)) {
+        foreach ($Ways as $i => $way) {
+            if (($way['Table'] == $index) || ($way['Graph'] == $index)) {
+                $index = $i;
+                break;
+            }
+        }
+    }
+
+    if (!is_numeric($index) || !isset($Ways[$index])) {
+        throw new Exception("Cannot find way '$index'");
+    }
+
+    if (is_null($element)) {
+        return $Ways[$index];
+    }
+
+    if ($element == 'Index') {
+        return $index;
+    }
+
+    if (array_key_exists($element, $Ways[$index])) {
+        return $Ways[$index][$element];
+    }
+
+    throw new Exception("'$element' is not a known parameter for ways");
+}


### PR DESCRIPTION
Move the captions and function names out of the main page file into a file that just returns configuration. Makes the code cleaner, and also sets us up to move to Ajax-imported results.