### PR TITLE
Set an explicit PHP session name

### DIFF
--- a/docker-web/php-extra.ini
+++ b/docker-web/php-extra.ini
@@ -6,3 +6,4 @@ opcache.enable=1
 
 session.save_handler = redis
 session.save_path = "tcp://${REDISSERVER}:6379"
+session.name = PHPPerformanceSession


### PR DESCRIPTION
Should avoid clashes where there are multiple things using localhost. 
NB requires a rebuild.
